### PR TITLE
Added organization CRUD (backend)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2395,6 +2395,11 @@
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -2514,8 +2519,45 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "arg": {
       "version": "4.1.3",
@@ -2896,6 +2938,15 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "bcrypt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.0.0.tgz",
+      "integrity": "sha512-jB0yCBl4W/kVHM2whjfyqnxTmOHkCX4kHEa5nYKSoGeYe8YrjTYTc87/6bwt1g8cmV0QrbhKriETg9jWtcREhg==",
+      "requires": {
+        "node-addon-api": "^3.0.0",
+        "node-pre-gyp": "0.15.0"
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -3303,8 +3354,7 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.2",
@@ -3521,6 +3571,11 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
     "collect-v8-coverage": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
@@ -3639,6 +3694,11 @@
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -3908,6 +3968,11 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -3985,6 +4050,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -4004,6 +4074,11 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -5455,6 +5530,14 @@
         "universalify": "^1.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "requires": {
+        "minipass": "^2.6.0"
+      }
+    },
     "fs-monkey": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.1.tgz",
@@ -5496,6 +5579,49 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.1",
@@ -5639,6 +5765,11 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "has-value": {
       "version": "1.0.0",
@@ -5844,6 +5975,14 @@
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
       "dev": true
     },
+    "ignore-walk": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+      "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+      "requires": {
+        "minimatch": "^3.0.4"
+      }
+    },
     "import-fresh": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
@@ -5934,6 +6073,11 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.2.0",
@@ -9191,6 +9335,23 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "requires": {
+        "minipass": "^2.9.0"
+      }
+    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -9371,6 +9532,31 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "needle": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.0.tgz",
+      "integrity": "sha512-o/qITSDR0JCyCKEQ1/1bnUXMmznxabbwi/Y4WwJElf+evwJNFNwIDMCCt5IigFVxgeGBJESLohGtIS9gEzo1fA==",
+      "requires": {
+        "debug": "^3.2.6",
+        "iconv-lite": "^0.4.4",
+        "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -9392,6 +9578,11 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node-addon-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.0.tgz",
+      "integrity": "sha512-sSHCgWfJ+Lui/u+0msF3oyCgvdkhxDbkCS6Q8uiJquzOimkJBvX6hl5aSSA7DR1XbMpdM8r7phjcF63sF4rkKg=="
     },
     "node-emoji": {
       "version": "1.10.0",
@@ -9558,6 +9749,42 @@
         }
       }
     },
+    "node-pre-gyp": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
+      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "requires": {
+        "detect-libc": "^1.0.2",
+        "mkdirp": "^0.5.3",
+        "needle": "^2.5.0",
+        "nopt": "^4.0.1",
+        "npm-packlist": "^1.1.6",
+        "npmlog": "^4.0.2",
+        "rc": "^1.2.7",
+        "rimraf": "^2.6.1",
+        "semver": "^5.3.0",
+        "tar": "^4.4.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -9576,6 +9803,29 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "npm-bundled": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+      "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+      "requires": {
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+    },
+    "npm-packlist": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+      "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+      "requires": {
+        "ignore-walk": "^3.0.1",
+        "npm-bundled": "^1.0.1",
+        "npm-normalize-package-bin": "^1.0.1"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -9584,6 +9834,22 @@
       "requires": {
         "path-key": "^2.0.0"
       }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -9811,6 +10077,11 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
     "os-name": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
@@ -9824,8 +10095,16 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
+      }
     },
     "p-each-series": {
       "version": "2.1.0",
@@ -10298,6 +10577,24 @@
         "unpipe": "1.0.0"
       }
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -10742,8 +11039,7 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -10891,8 +11187,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -11584,6 +11879,20 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
       "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
       "dev": true
+    },
+    "tar": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "fs-minipass": "^1.2.5",
+        "minipass": "^2.8.6",
+        "minizlib": "^1.2.1",
+        "mkdirp": "^0.5.0",
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.3"
+      }
     },
     "terminal-link": {
       "version": "2.1.1",
@@ -12830,6 +13139,43 @@
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "windows-release": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
@@ -12959,8 +13305,7 @@
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2059,6 +2059,11 @@
         }
       }
     },
+    "@types/validator": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.0.0.tgz",
+      "integrity": "sha512-WAy5txG7aFX8Vw3sloEKp5p/t/Xt8jD3GRD9DacnFv6Vo8ubudAsRTXgxpQwU0mpzY/H8U4db3roDuCMjShBmw=="
+    },
     "@types/webpack": {
       "version": "4.41.17",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.17.tgz",
@@ -3389,6 +3394,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "class-transformer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.2.3.tgz",
+      "integrity": "sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -3410,6 +3420,17 @@
             "is-descriptor": "^0.1.0"
           }
         }
+      }
+    },
+    "class-validator": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.12.2.tgz",
+      "integrity": "sha512-TDzPzp8BmpsbPhQpccB3jMUE/3pK0TyqamrK0kcx+ZeFytMA+O6q87JZZGObHHnoo9GM8vl/JppIyKWeEA/EVw==",
+      "requires": {
+        "@types/validator": "13.0.0",
+        "google-libphonenumber": "^3.2.8",
+        "tslib": ">=1.9.0",
+        "validator": "13.0.0"
       }
     },
     "cli-color": {
@@ -5708,6 +5729,11 @@
           "dev": true
         }
       }
+    },
+    "google-libphonenumber": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/google-libphonenumber/-/google-libphonenumber-3.2.10.tgz",
+      "integrity": "sha512-TsckE9O8QgqaIeaOXPjcJa4/kX3BzFdO1oCbMfmUpRZckml4xJhjJVxaT9Mdt/VrZZkT9lX44eHAEWfJK1tHtw=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -12692,6 +12718,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
+      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^7.0.0",
     "@nestjs/platform-express": "^7.0.0",
     "@nestjs/typeorm": "^7.1.0",
+    "bcrypt": "^5.0.0",
     "mysql": "^2.18.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,8 @@
     "@nestjs/platform-express": "^7.0.0",
     "@nestjs/typeorm": "^7.1.0",
     "bcrypt": "^5.0.0",
+    "class-transformer": "^0.2.3",
+    "class-validator": "^0.12.2",
     "mysql": "^2.18.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { OrganizationsModule } from './organizations/organizations.module';
 
 @Module({
   imports: [
@@ -10,10 +11,10 @@ import { AppService } from './app.service';
     TypeOrmModule.forRoot({
       type: 'mysql',
       url: process.env.DATABASE_URL,
-      entities: [],
       autoLoadEntities: true,
       synchronize: process.env.NODE_ENV !== 'production',
     }),
+    OrganizationsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,9 +1,11 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.enableCors();
+  app.useGlobalPipes(new ValidationPipe());
   await app.listen(process.env.PORT || 4000);
 }
 bootstrap();

--- a/backend/src/organizations/organization.dto.ts
+++ b/backend/src/organizations/organization.dto.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsMobilePhone, IsNotEmpty, IsString, Length, MaxLength } from 'class-validator';
+import { IsEmail, IsMobilePhone, IsNotEmpty, IsString, Length, MaxLength, IsOptional } from 'class-validator';
 
 export class OrganizationDto {
   @Length(10, 10)
@@ -20,6 +20,7 @@ export class OrganizationDto {
   @IsEmail()
   email: string;
   
+  @IsOptional()
   @Length(8, 128)
   @IsString()
   password: string;

--- a/backend/src/organizations/organization.dto.ts
+++ b/backend/src/organizations/organization.dto.ts
@@ -1,10 +1,36 @@
+import { IsEmail, IsMobilePhone, IsNotEmpty, IsString, Length, MaxLength } from 'class-validator';
+
 export class OrganizationDto {
+  @Length(10, 10)
+  @IsString()
   EIN: string;
+  
+  @IsNotEmpty()
+  @IsString()
   name: string;
+  
+  @IsNotEmpty()
+  @MaxLength(1000)
+  @IsString()
   description: string;
+
+  @IsMobilePhone('en-US')
   phoneNumber: string;
+  
+  @IsEmail()
   email: string;
+  
+  @Length(8, 128)
+  @IsString()
   password: string;
+  
+  @IsNotEmpty()
+  @MaxLength(100)
+  @IsString()
   contactFirstName: string;
+  
+  @IsNotEmpty()
+  @MaxLength(100)
+  @IsString()
   contactLastName: string;
 }

--- a/backend/src/organizations/organization.dto.ts
+++ b/backend/src/organizations/organization.dto.ts
@@ -1,0 +1,10 @@
+export class OrganizationDto {
+  EIN: string;
+  name: string;
+  description: string;
+  phoneNumber: string;
+  email: string;
+  password: string;
+  contactFirstName: string;
+  contactLastName: string;
+}

--- a/backend/src/organizations/organization.entity.spec.ts
+++ b/backend/src/organizations/organization.entity.spec.ts
@@ -1,0 +1,61 @@
+import { Organization } from './organization.entity';
+
+describe('Organization entity', () => {
+  it('should make an organization with no fields', () => {
+    const organization = new Organization();
+    expect(organization).toBeTruthy();
+    expect(organization.id).toBe(undefined);
+    expect(organization.EIN).toBe(undefined);
+    expect(organization.name).toBe(undefined);
+    expect(organization.description).toBe(undefined);
+    expect(organization.phoneNumber).toBe(undefined);
+    expect(organization.email).toBe(undefined);
+    expect(organization.contactFirstName).toBe(undefined);
+    expect(organization.contactLastName).toBe(undefined);
+    expect(organization.encryptedPassword).toBe(undefined);
+  });
+
+  it('should make an organization with some fields', () => {
+    const organization = new Organization(
+      0,
+      '1234',
+      'orgname',
+      undefined,
+      '514-123-4567',
+    );
+    expect(organization).toBeTruthy();
+    expect(organization.id).toBe(0);
+    expect(organization.EIN).toBe('1234');
+    expect(organization.name).toBe('orgname');
+    expect(organization.description).toBe(undefined);
+    expect(organization.phoneNumber).toBe('514-123-4567');
+    expect(organization.email).toBe(undefined);
+    expect(organization.contactFirstName).toBe(undefined);
+    expect(organization.contactLastName).toBe(undefined);
+    expect(organization.encryptedPassword).toBe(undefined);
+  });
+
+  it('should make an organization with all fields', () => {
+    const organization = new Organization(
+      0,
+      '1234',
+      '',
+      'org description',
+      '514-123-4567',
+      'email@email.com',
+      'first name',
+      'last name',
+      'secret password',
+    );
+    expect(organization).toBeTruthy();
+    expect(organization.id).toBe(0);
+    expect(organization.EIN).toBe('1234');
+    expect(organization.name).toBe('');
+    expect(organization.description).toBe('org description');
+    expect(organization.phoneNumber).toBe('514-123-4567');
+    expect(organization.email).toBe('email@email.com');
+    expect(organization.contactFirstName).toBe('first name');
+    expect(organization.contactLastName).toBe('last name');
+    expect(organization.encryptedPassword).toBe('secret password');
+  });
+});

--- a/backend/src/organizations/organization.entity.ts
+++ b/backend/src/organizations/organization.entity.ts
@@ -23,7 +23,7 @@ export class Organization {
   @Column()
   phoneNumber: string;
 
-  @Column()
+  @Column({ unique: true })
   email: string;
 
   @Column()

--- a/backend/src/organizations/organization.entity.ts
+++ b/backend/src/organizations/organization.entity.ts
@@ -32,7 +32,7 @@ export class Organization {
   @Column()
   contactLastName: string;
 
-  @Column({ nullable: false })
+  @Column({ nullable: false, select: false })
   encryptedPassword: string;
 
   @Column()
@@ -42,4 +42,26 @@ export class Organization {
   @Column()
   @UpdateDateColumn()
   updatedAt: Date;
+
+  constructor(
+    id?: number,
+    EIN?: string,
+    name?: string,
+    description?: string,
+    phoneNumber?: string,
+    email?: string,
+    contactFirstName?: string,
+    contactLastName?: string,
+    encryptedPassword?: string,
+  ) {
+    this.id = id;
+    this.EIN = EIN;
+    this.name = name;
+    this.description = description;
+    this.phoneNumber = phoneNumber;
+    this.email = email;
+    this.contactFirstName = contactFirstName;
+    this.contactLastName = contactLastName;
+    this.encryptedPassword = encryptedPassword;
+  }
 }

--- a/backend/src/organizations/organization.entity.ts
+++ b/backend/src/organizations/organization.entity.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity()
+export class Organization {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  EIN: string;
+
+  @Column()
+  name: string;
+
+  @Column({ length: '1023' })
+  description: string;
+
+  @Column()
+  phoneNumber: string;
+
+  @Column()
+  email: string;
+
+  @Column()
+  contactFirstName: string;
+
+  @Column()
+  contactLastName: string;
+
+  @Column({ nullable: false })
+  encryptedPassword: string;
+
+  @Column()
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column()
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/organizations/organization.repository.ts
+++ b/backend/src/organizations/organization.repository.ts
@@ -1,4 +1,0 @@
-import { Organization } from './organization.entity';
-import { Repository } from 'typeorm';
-
-export class OrganizationRepository extends Repository<Organization> {}

--- a/backend/src/organizations/organization.repository.ts
+++ b/backend/src/organizations/organization.repository.ts
@@ -1,0 +1,4 @@
+import { Organization } from './organization.entity';
+import { Repository } from 'typeorm';
+
+export class OrganizationRepository extends Repository<Organization> {}

--- a/backend/src/organizations/organizations.controller.spec.ts
+++ b/backend/src/organizations/organizations.controller.spec.ts
@@ -45,11 +45,9 @@ describe('Organization Controller', () => {
 
             findOne: jest
               .fn()
-              .mockImplementation((id: String) =>
+              .mockImplementation((id: number) =>
                 Promise.resolve(
-                  mockDatabase.find(
-                    organization => organization.id === Number(id),
-                  ),
+                  mockDatabase.find(organization => organization.id === id),
                 ),
               ),
 
@@ -65,7 +63,7 @@ describe('Organization Controller', () => {
               .mockImplementation(
                 (id: number, organizationData: OrganizationDto) => {
                   const organizationToUpdate = mockDatabase.find(
-                    organization => organization.id === Number(id),
+                    organization => organization.id === id,
                   );
                   delete organizationData.password;
 

--- a/backend/src/organizations/organizations.controller.spec.ts
+++ b/backend/src/organizations/organizations.controller.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OrganizationsController } from './organizations.controller';
+import { OrganizationsService } from './organizations.service';
+import { Organization } from './organization.entity';
+
+describe('Organizations Controller', () => {
+  let module: TestingModule;
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      controllers: [OrganizationsController],
+      providers: [
+        OrganizationsService,
+        {
+          provide: getRepositoryToken(Organization),
+          useValue: {},
+        },
+      ],
+    }).compile();
+  });
+  
+  it('should be defined', () => {
+    const controller: OrganizationsController = module.get<
+      OrganizationsController
+    >(OrganizationsController);
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/organizations/organizations.controller.spec.ts
+++ b/backend/src/organizations/organizations.controller.spec.ts
@@ -1,28 +1,168 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
 import { OrganizationsController } from './organizations.controller';
+import { OrganizationDto } from './organization.dto';
 import { OrganizationsService } from './organizations.service';
-import { Organization } from './organization.entity';
+import { Organization } from './Organization.entity';
 
-describe('Organizations Controller', () => {
-  let module: TestingModule;
-  beforeAll(async () => {
-    module = await Test.createTestingModule({
+const mockData = [
+  new Organization(
+    0,
+    '12-3456789',
+    'organization name',
+    'organization description',
+    '+001 (012) 012-0123',
+    'johndoe@email.com',
+    'John',
+    'Doe',
+  ),
+  new Organization(
+    1,
+    '34-5678901',
+    'organization name 2',
+    'organization description 2',
+    '+002 (123) 456-7890',
+    'janedoe@email.com',
+    'Jane',
+    'Doe',
+  ),
+];
+
+let mockDatabase: Organization[] = [];
+
+describe('Organization Controller', () => {
+  let controller: OrganizationsController;
+  let service: OrganizationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
       controllers: [OrganizationsController],
+
       providers: [
-        OrganizationsService,
         {
-          provide: getRepositoryToken(Organization),
-          useValue: {},
+          provide: OrganizationsService,
+          useValue: {
+            findAll: jest.fn().mockResolvedValue(mockDatabase),
+
+            findOne: jest
+              .fn()
+              .mockImplementation((id: String) =>
+                Promise.resolve(
+                  mockDatabase.find(
+                    organization => organization.id === Number(id),
+                  ),
+                ),
+              ),
+
+            create: jest
+              .fn()
+              .mockImplementation((organization: OrganizationDto) => {
+                delete organization.password;
+                return Promise.resolve({ id: 2, ...organization });
+              }),
+
+            update: jest
+              .fn()
+              .mockImplementation(
+                (id: number, organizationData: OrganizationDto) => {
+                  const organizationToUpdate = mockDatabase.find(
+                    organization => organization.id === Number(id),
+                  );
+                  delete organizationData.password;
+
+                  // like Object.assign, but for defined properties
+                  for (const key of Object.keys(organizationData)) {
+                    const value = organizationData[key];
+                    if (value !== undefined) {
+                      organizationToUpdate[key] = value;
+                    }
+                  }
+                  return Promise.resolve({ id: 0, ...organizationToUpdate });
+                },
+              ),
+
+            remove: jest.fn().mockResolvedValue(Promise.resolve()),
+          },
         },
       ],
     }).compile();
+
+    mockDatabase = mockData.map(organization => ({ ...organization }));
+    controller = module.get<OrganizationsController>(OrganizationsController);
+    service = module.get<OrganizationsService>(OrganizationsService);
   });
-  
+
   it('should be defined', () => {
-    const controller: OrganizationsController = module.get<
-      OrganizationsController
-    >(OrganizationsController);
     expect(controller).toBeDefined();
+  });
+
+  describe('findAll', () => {
+    it('should get an array of organizations', () => {
+      expect(controller.findAll()).resolves.toEqual(mockDatabase);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should get an organization', () => {
+      expect(controller.findOne('0')).resolves.toEqual(mockDatabase[0]);
+      expect(controller.findOne('1')).resolves.toEqual(mockDatabase[1]);
+    });
+  });
+
+  describe('create', () => {
+    it('should create an organization', () => {
+      const newOrganization: OrganizationDto = {
+        EIN: '12-3456789',
+        name: 'Apple',
+        description: 'The apple company',
+        phoneNumber: '+001 (012) 012-0123',
+        email: 'stevejobs@apple.com',
+        password: 'strongpassword',
+        contactFirstName: 'Steve',
+        contactLastName: 'Jobs',
+      };
+      expect(controller.create(newOrganization)).resolves.toEqual({
+        id: 2,
+        ...newOrganization,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('should update an organization', async () => {
+      const newData = {
+        EIN: undefined,
+        name: 'new name',
+        description: undefined,
+        phoneNumber: undefined,
+        email: 'newemail@email.com',
+        password: undefined,
+        contactFirstName: undefined,
+        contactLastName: undefined,
+      };
+      const beforeUpdate = mockDatabase[0];
+      const updatedOrganization = await controller.update('0', newData);
+      expect(beforeUpdate.id).toEqual(updatedOrganization.id);
+      expect(beforeUpdate.EIN).toEqual(updatedOrganization.EIN);
+      expect(newData.name).toEqual(updatedOrganization.name);
+      expect(beforeUpdate.description).toEqual(updatedOrganization.description);
+      expect(beforeUpdate.phoneNumber).toEqual(updatedOrganization.phoneNumber);
+      expect(newData.email).toEqual(updatedOrganization.email);
+      expect(beforeUpdate.contactFirstName).toEqual(
+        updatedOrganization.contactFirstName,
+      );
+      expect(beforeUpdate.contactLastName).toEqual(
+        updatedOrganization.contactLastName,
+      );
+      expect(beforeUpdate.EIN).toEqual(updatedOrganization.EIN);
+      expect(beforeUpdate.EIN).toEqual(updatedOrganization.EIN);
+      expect(beforeUpdate.EIN).toEqual(updatedOrganization.EIN);
+    });
+  });
+
+  describe('update', () => {
+    it('should delete an organization', async () => {
+      //! nothing is returns so it only tests if it crashes
+      await controller.remove('0');
+    });
   });
 });

--- a/backend/src/organizations/organizations.controller.spec.ts
+++ b/backend/src/organizations/organizations.controller.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { OrganizationsController } from './organizations.controller';
 import { OrganizationDto } from './organization.dto';
 import { OrganizationsService } from './organizations.service';
-import { Organization } from './Organization.entity';
+import { Organization } from './organization.entity';
 
 const mockData = [
   new Organization(

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -8,8 +8,8 @@ import {
   Put,
 } from '@nestjs/common';
 import { OrganizationDto } from './organization.dto';
-import { Organization } from './Organization.entity';
-import { OrganizationsService } from './Organizations.service';
+import { Organization } from './organization.entity';
+import { OrganizationsService } from './organizations.service';
 
 @Controller('organizations')
 export class OrganizationsController {

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
+import { OrganizationDto } from './organization.dto';
+import { Organization } from './Organization.entity';
+import { OrganizationsService } from './Organizations.service';
+
+@Controller('organizations')
+export class OrganizationsController {
+  constructor(private readonly OrganizationsService: OrganizationsService) {}
+
+  @Post()
+  create(
+    @Body() createOrganizationDto: OrganizationDto,
+  ): Promise<Organization> {
+    return this.OrganizationsService.create(createOrganizationDto);
+  }
+
+  @Get()
+  findAll(): Promise<Organization[]> {
+    return this.OrganizationsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<Organization> {
+    return this.OrganizationsService.findOne(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() organization: OrganizationDto) {
+    return this.OrganizationsService.update(Number(id), organization);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string): Promise<void> {
+    return this.OrganizationsService.remove(id);
+  }
+}

--- a/backend/src/organizations/organizations.controller.ts
+++ b/backend/src/organizations/organizations.controller.ts
@@ -29,7 +29,7 @@ export class OrganizationsController {
 
   @Get(':id')
   findOne(@Param('id') id: string): Promise<Organization> {
-    return this.OrganizationsService.findOne(id);
+    return this.OrganizationsService.findOne(Number(id));
   }
 
   @Put(':id')
@@ -39,6 +39,6 @@ export class OrganizationsController {
 
   @Delete(':id')
   remove(@Param('id') id: string): Promise<void> {
-    return this.OrganizationsService.remove(id);
+    return this.OrganizationsService.remove(Number(id));
   }
 }

--- a/backend/src/organizations/organizations.module.ts
+++ b/backend/src/organizations/organizations.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Organization } from './organization.entity';
+import { OrganizationsService } from './organizations.service';
+import { OrganizationsController } from './organizations.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Organization])],
+  providers: [OrganizationsService],
+  controllers: [OrganizationsController],
+})
+export class OrganizationsModule {}

--- a/backend/src/organizations/organizations.service.spec.ts
+++ b/backend/src/organizations/organizations.service.spec.ts
@@ -46,9 +46,9 @@ describe('OrganizationsService', () => {
 
             findOne: jest
               .fn()
-              .mockImplementation((id: String) =>
+              .mockImplementation((id: number) =>
                 mockDatabase.find(
-                  organization => organization.id === Number(id),
+                  organization => organization.id === id,
                 ),
               ),
 
@@ -77,7 +77,7 @@ describe('OrganizationsService', () => {
               .mockImplementation(
                 (id: number, organizationData: OrganizationDto) => {
                   const organizationToUpdate = mockDatabase.find(
-                    organization => organization.id === Number(id),
+                    organization => organization.id === id,
                   );
                   if (organizationData.password) {
                     organizationToUpdate.encryptedPassword = OrganizationsService.encrypt(
@@ -95,9 +95,9 @@ describe('OrganizationsService', () => {
                 },
               ),
 
-            delete: jest.fn().mockImplementation((id: String) => {
+            delete: jest.fn().mockImplementation((id: number) => {
               mockDatabase = mockDatabase.filter(
-                organization => organization.id !== Number(id),
+                organization => organization.id !== id,
               );
             }),
           },
@@ -146,7 +146,7 @@ describe('OrganizationsService', () => {
 
   describe('findOne', () => {
     it('should get a single organization', () => {
-      expect(service.findOne('0')).toEqual(mockDatabase[0]);
+      expect(service.findOne(0)).toEqual(mockDatabase[0]);
     });
   });
 
@@ -167,7 +167,7 @@ describe('OrganizationsService', () => {
       await service.create(newOrganization);
       expect(mockDatabase.length).toEqual(beforeCount + 1);
 
-      const createdOrganization = await service.findOne(String(beforeCount));
+      const createdOrganization = await service.findOne(beforeCount);
       expect(createdOrganization.EIN).toEqual(newOrganization.EIN);
       expect(createdOrganization.name).toEqual(newOrganization.name);
       expect(createdOrganization.description).toEqual(
@@ -248,7 +248,7 @@ describe('OrganizationsService', () => {
   describe('remove', () => {
     it('should delete an organization', async () => {
       const beforeCount = mockDatabase.length;
-      await service.remove('0');
+      await service.remove(0);
       expect(mockDatabase.length).toEqual(beforeCount - 1);
     });
   });

--- a/backend/src/organizations/organizations.service.spec.ts
+++ b/backend/src/organizations/organizations.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OrganizationsService } from './organizations.service';
+import { Organization } from './organization.entity';
+import { OrganizationRepository } from './organization.repository';
+
+describe('Organizations Service', () => {
+  let service: OrganizationsService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrganizationsService,
+        {
+          provide: getRepositoryToken(Organization),
+          useClass: OrganizationRepository,
+        },
+      ],
+    }).compile();
+    service = module.get<OrganizationsService>(OrganizationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/organizations/organizations.service.spec.ts
+++ b/backend/src/organizations/organizations.service.spec.ts
@@ -1,26 +1,255 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import * as bcrypt from 'bcrypt';
+import { Repository } from 'typeorm';
 import { OrganizationsService } from './organizations.service';
 import { Organization } from './organization.entity';
-import { OrganizationRepository } from './organization.repository';
+import { OrganizationDto } from './organization.dto';
 
-describe('Organizations Service', () => {
+const mockData = [
+  new Organization(
+    0,
+    '12-3456789',
+    'organization name',
+    'organization description',
+    '+001 (012) 012-0123',
+    'johndoe@email.com',
+    'John',
+    'Doe',
+  ),
+  new Organization(
+    1,
+    '34-5678901',
+    'organization name 2',
+    'organization description 2',
+    '+002 (123) 456-7890',
+    'janedoe@email.com',
+    'Jane',
+    'Doe',
+  ),
+];
+
+let mockDatabase: Organization[] = [];
+
+describe('OrganizationsService', () => {
   let service: OrganizationsService;
+  let repo: Repository<Organization>;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         OrganizationsService,
         {
           provide: getRepositoryToken(Organization),
-          useClass: OrganizationRepository,
+          useValue: {
+            find: jest.fn().mockResolvedValue(mockDatabase),
+
+            findOne: jest
+              .fn()
+              .mockImplementation((id: String) =>
+                mockDatabase.find(
+                  organization => organization.id === Number(id),
+                ),
+              ),
+
+            create: jest
+              .fn()
+              .mockImplementation((organization: OrganizationDto) => {
+                const newOrganization = new Organization(
+                  mockDatabase.length,
+                  organization.EIN,
+                  organization.name,
+                  organization.description,
+                  organization.phoneNumber,
+                  organization.email,
+                  organization.contactFirstName,
+                  organization.contactLastName,
+                );
+
+                mockDatabase.push(newOrganization);
+                return newOrganization;
+              }),
+
+            save: jest.fn(),
+
+            update: jest
+              .fn()
+              .mockImplementation(
+                (id: number, organizationData: OrganizationDto) => {
+                  const organizationToUpdate = mockDatabase.find(
+                    organization => organization.id === Number(id),
+                  );
+                  if (organizationData.password) {
+                    organizationToUpdate.encryptedPassword = OrganizationsService.encrypt(
+                      organizationData.password,
+                    );
+                    delete organizationData.password;
+                  }
+                  // like Object.assign, but for defined properties
+                  for (const key of Object.keys(organizationData)) {
+                    const value = organizationData[key];
+                    if (value !== undefined) {
+                      organizationToUpdate[key] = value;
+                    }
+                  }
+                },
+              ),
+
+            delete: jest.fn().mockImplementation((id: String) => {
+              mockDatabase = mockDatabase.filter(
+                organization => organization.id !== Number(id),
+              );
+            }),
+          },
         },
       ],
     }).compile();
+
+    mockDatabase = mockData.map(organization => ({ ...organization }));
     service = module.get<OrganizationsService>(OrganizationsService);
+    repo = module.get<Repository<Organization>>(
+      getRepositoryToken(Organization),
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('util functions', () => {
+    it('should encrypt the password', () => {
+      expect(
+        bcrypt.compareSync(
+          'password',
+          OrganizationsService.encrypt('password'),
+        ),
+      ).toBeTruthy();
+      expect(
+        bcrypt.compareSync('', OrganizationsService.encrypt('')),
+      ).toBeTruthy();
+    });
+    it('should detect that its the wrong password', () => {
+      expect(
+        bcrypt.compareSync(
+          'not same password',
+          OrganizationsService.encrypt('password'),
+        ),
+      ).toBeFalsy();
+    });
+  });
+
+  describe('find', () => {
+    it('should get all the organizations', () => {
+      expect(service.findAll()).resolves.toEqual(mockDatabase);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should get a single organization', () => {
+      expect(service.findOne('0')).toEqual(mockDatabase[0]);
+    });
+  });
+
+  describe('create', () => {
+    it('should successfully create an organization', async () => {
+      const newOrganization: OrganizationDto = {
+        EIN: '12-3456789',
+        name: 'Apple',
+        description: 'The apple company',
+        phoneNumber: '+001 (012) 012-0123',
+        email: 'stevejobs@apple.com',
+        password: 'strongpassword',
+        contactFirstName: 'Steve',
+        contactLastName: 'Jobs',
+      };
+
+      const beforeCount = mockDatabase.length;
+      await service.create(newOrganization);
+      expect(mockDatabase.length).toEqual(beforeCount + 1);
+
+      const createdOrganization = await service.findOne(String(beforeCount));
+      expect(createdOrganization.EIN).toEqual(newOrganization.EIN);
+      expect(createdOrganization.name).toEqual(newOrganization.name);
+      expect(createdOrganization.description).toEqual(
+        newOrganization.description,
+      );
+      expect(createdOrganization.phoneNumber).toEqual(
+        newOrganization.phoneNumber,
+      );
+      expect(createdOrganization.email).toEqual(newOrganization.email);
+      expect(createdOrganization.contactFirstName).toEqual(
+        newOrganization.contactFirstName,
+      );
+      expect(createdOrganization.contactLastName).toEqual(
+        newOrganization.contactLastName,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update an organization without password', async () => {
+      const newData = {
+        EIN: undefined,
+        name: 'new name',
+        description: undefined,
+        phoneNumber: undefined,
+        email: 'newemail@email.com',
+        password: undefined,
+        contactFirstName: undefined,
+        contactLastName: undefined,
+      };
+      const beforeUpdate = mockDatabase[0];
+      await service.update(0, newData);
+
+      expect(mockDatabase[0].EIN).toEqual(beforeUpdate.EIN);
+      expect(mockDatabase[0].name).toEqual(newData.name);
+      expect(mockDatabase[0].description).toEqual(beforeUpdate.description);
+      expect(mockDatabase[0].phoneNumber).toEqual(beforeUpdate.phoneNumber);
+      expect(mockDatabase[0].email).toEqual(newData.email);
+      expect(mockDatabase[0].contactFirstName).toEqual(
+        beforeUpdate.contactFirstName,
+      );
+      expect(mockDatabase[0].contactLastName).toEqual(
+        beforeUpdate.contactLastName,
+      );
+    });
+
+    it('should update an organization with password', async () => {
+      const newData = {
+        EIN: undefined,
+        name: undefined,
+        description: undefined,
+        phoneNumber: undefined,
+        email: undefined,
+        password: 'new password',
+        contactFirstName: 'Steve',
+        contactLastName: 'Jobs',
+      };
+      const password = newData.password;
+      const beforeUpdate = mockDatabase[0];
+      await service.update(0, newData);
+
+      expect(
+        bcrypt.compareSync(password, mockDatabase[0].encryptedPassword),
+      ).toBeTruthy();
+
+      expect(mockDatabase[0].EIN).toEqual(beforeUpdate.EIN);
+      expect(mockDatabase[0].name).toEqual(beforeUpdate.name);
+      expect(mockDatabase[0].description).toEqual(beforeUpdate.description);
+      expect(mockDatabase[0].phoneNumber).toEqual(beforeUpdate.phoneNumber);
+      expect(mockDatabase[0].email).toEqual(beforeUpdate.email);
+      expect(mockDatabase[0].contactFirstName).toEqual(
+        newData.contactFirstName,
+      );
+      expect(mockDatabase[0].contactLastName).toEqual(newData.contactLastName);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete an organization', async () => {
+      const beforeCount = mockDatabase.length;
+      await service.remove('0');
+      expect(mockDatabase.length).toEqual(beforeCount - 1);
+    });
   });
 });

--- a/backend/src/organizations/organizations.service.ts
+++ b/backend/src/organizations/organizations.service.ts
@@ -27,7 +27,7 @@ export class OrganizationsService {
     return this.organizationsRepository.find();
   }
 
-  findOne(id: string): Promise<Organization> {
+  async findOne(id: number): Promise<Organization> {
     return this.organizationsRepository.findOne(id);
   }
 
@@ -46,7 +46,7 @@ export class OrganizationsService {
     return this.organizationsRepository.findOne(id);
   }
 
-  async remove(id: string): Promise<void> {
+  async remove(id: number): Promise<void> {
     await this.organizationsRepository.delete(id);
   }
 

--- a/backend/src/organizations/organizations.service.ts
+++ b/backend/src/organizations/organizations.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { OrganizationDto } from './organization.dto';
+import { Organization } from './organization.entity';
+
+@Injectable()
+export class OrganizationsService {
+  constructor(
+    @InjectRepository(Organization)
+    private readonly organizationsRepository: Repository<Organization>,
+  ) {}
+
+  create(createOrganizationDto: OrganizationDto): Promise<Organization> {
+    const organization = this.organizationsRepository.create(
+      createOrganizationDto,
+    );
+    organization.encryptedPassword = OrganizationsService.encrypt(
+      createOrganizationDto.password,
+    );
+
+    return this.organizationsRepository.save(organization);
+  }
+
+  async findAll(): Promise<Organization[]> {
+    return this.organizationsRepository.find();
+  }
+
+  findOne(id: string): Promise<Organization> {
+    return this.organizationsRepository.findOne(id);
+  }
+
+  public async update(
+    id: number,
+    organization: OrganizationDto,
+  ): Promise<Organization> {
+    if (organization.password) {
+      await this.organizationsRepository.update(id, {
+        encryptedPassword: OrganizationsService.encrypt(organization.password),
+      });
+      delete organization.password;
+    }
+    await this.organizationsRepository.update(id, organization);
+
+    return this.organizationsRepository.findOne(id);
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.organizationsRepository.delete(id);
+  }
+
+  /**
+   * Returns the encrypted password using bcrypt
+   * @param password password to encrypt
+   */
+  private static encrypt(password: string): string {
+    return bcrypt.hashSync(password, 10);
+  }
+}

--- a/backend/src/organizations/organizations.service.ts
+++ b/backend/src/organizations/organizations.service.ts
@@ -54,7 +54,7 @@ export class OrganizationsService {
    * Returns the encrypted password using bcrypt
    * @param password password to encrypt
    */
-  private static encrypt(password: string): string {
+  public static encrypt(password: string): string {
     return bcrypt.hashSync(password, 10);
   }
 }


### PR DESCRIPTION
- Added basic CRUD for the organizations
- Tests for the organization's service, controller and entity

The organizations have these fields:

- `id: number` (auto generated)
- `EIN: string`
- `name: string`
- `description: string`
- `phoneNumber: string`
- `email: string`
- `contactFirstName: string`
- `contactLastName: string`
- `encryptedPassword: string`
- `createdAt: Date` (auto generated)
- `updatedAt: Date` (auto generated)

Some validation has been added in order to prevent invalid data (phone, email, etc.), but no guard (for the delete route for example) has been added because the authentication has not been implemented yet. 